### PR TITLE
Updated archiver version causing the error : Error: If encoding is sp…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rimraf": "2.x.x",
     "underscore": "1.7.0",
     "uuid": "1.4.x",
-    "archiver": "0.14.x",
+    "archiver": "1.0.0",
     "update-notifier": "0.4.x",
     "minimist": "1.1.1"
   },


### PR DESCRIPTION
…ecified then the first argument must be a string
